### PR TITLE
Add goal: allow trust between humans

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ These problems need solutions!
 * Give OSS maintainers better ability to ensure that project governance policies (like independent signoff) are followed.
 * Give OSS consumers tools to detect changes in activity from unknown contributors.
 * Allow consumers of open source to examine the full provenance of their open source supply-chains.
+* Allow trust between humans and do not require trusted intermediaries.
 
 For a full list of the threat models we are trying to address, see the [Threat Models](threat_models.md) document.
 


### PR DESCRIPTION
The other goals do not explicitly mention that decentralized trust is
preferred over requiring centralized trust. Make this explicit by adding
this goal. This is not merely something that arises from the threat
model, but is a goal in itself.

